### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main#cee15c1` to `dev-main#cdb4299`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2898,12 +2898,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "cee15c16811f29974605dd605c71bc464555b204"
+                "reference": "cdb4299c7eeaa4dfdba7f07939db077dc7a07747"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/cee15c16811f29974605dd605c71bc464555b204",
-                "reference": "cee15c16811f29974605dd605c71bc464555b204",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/cdb4299c7eeaa4dfdba7f07939db077dc7a07747",
+                "reference": "cdb4299c7eeaa4dfdba7f07939db077dc7a07747",
                 "shasum": ""
             },
             "require": {
@@ -2950,7 +2950,6 @@
             },
             "require-dev": {
                 "ext-xdebug": "*",
-                "ghostwriter/workbench": "0.1.x-dev",
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
                 "phpunit/phpunit": "~12.3.7",
@@ -3060,7 +3059,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-02T02:09:07+00:00"
+            "time": "2025-09-02T02:48:29+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#cee15c1` to `dev-main#cdb4299`.

This pull request changes the following file(s): 

- Update `composer.lock`