### PR TITLE
Bump `psr/http-message` to `2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "laminas/laminas-diactoros": "~3.6.0",
         "psr/http-client": "~1.0.3",
         "psr/http-factory": "~1.1.0",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "~2.0",
         "psr/http-server-handler": "~1.0.2",
         "psr/http-server-middleware": "~1.0.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bef65ab978f7534a177c895082b6dc6f",
+    "content-hash": "e37e217d8bc9dc14b31ee2d51ed4d040",
     "packages": [
         {
             "name": "fig/cache-util",


### PR DESCRIPTION
Bumps `psr/http-message` from `^2.0` to `2.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`