### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#17776b9`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2898,12 +2898,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "f46c5647930fbef9b2efe04bce978a6713eace5a"
+                "reference": "17776b9d6f4382441d4935aa212465b707f67782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f46c5647930fbef9b2efe04bce978a6713eace5a",
-                "reference": "f46c5647930fbef9b2efe04bce978a6713eace5a",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/17776b9d6f4382441d4935aa212465b707f67782",
+                "reference": "17776b9d6f4382441d4935aa212465b707f67782",
                 "shasum": ""
             },
             "require": {
@@ -3060,7 +3060,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T11:25:50+00:00"
+            "time": "2025-09-11T12:59:06+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#f46c564` to `dev-main#17776b9`.

This pull request changes the following file(s): 

- Update `composer.lock`