### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#b41b8c9`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "laminas/laminas-diactoros": "~3.6.0",
         "psr/http-client": "~1.0.3",
         "psr/http-factory": "~1.1.0",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "~2.0",
         "psr/http-server-handler": "~1.0.2",
         "psr/http-server-middleware": "~1.0.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ef8e77c816d217d8d831626a0015f68",
+    "content-hash": "18e69031d6072d4204d2fe276ae10fbc",
     "packages": [
         {
             "name": "fig/cache-util",
@@ -2898,12 +2898,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "025d1d15b3d612deda2ff7d026afa6f7f1379411"
+                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/025d1d15b3d612deda2ff7d026afa6f7f1379411",
-                "reference": "025d1d15b3d612deda2ff7d026afa6f7f1379411",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/b41b8c9261587c68541e6bf38933426ce8b9c8db",
+                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db",
                 "shasum": ""
             },
             "require": {
@@ -3060,7 +3060,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T16:38:56+00:00"
+            "time": "2025-09-11T17:06:16+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#025d1d1` to `dev-main#b41b8c9`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`