### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#0179b4d`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "laminas/laminas-diactoros": "~3.6.0",
         "psr/http-client": "~1.0.3",
         "psr/http-factory": "~1.1.0",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "~2.0",
         "psr/http-server-handler": "~1.0.2",
         "psr/http-server-middleware": "~1.0.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e439d56ffb5122f2eb6a0de1ea9933b3",
+    "content-hash": "4a7dbb805c46f7801f3f7d479cb99b41",
     "packages": [
         {
             "name": "fig/cache-util",
@@ -2898,12 +2898,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "e36feb1383bc8bb3c86c9ffefa3a39c150bab091"
+                "reference": "0179b4d7e11176787d7fd01cf136ac32a79a6485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e36feb1383bc8bb3c86c9ffefa3a39c150bab091",
-                "reference": "e36feb1383bc8bb3c86c9ffefa3a39c150bab091",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/0179b4d7e11176787d7fd01cf136ac32a79a6485",
+                "reference": "0179b4d7e11176787d7fd01cf136ac32a79a6485",
                 "shasum": ""
             },
             "require": {
@@ -2958,10 +2958,10 @@
             },
             "default-branch": true,
             "bin": [
+                "tools/phar/composer",
                 "tools/phar/composer-normalize",
                 "tools/phar/composer-require-checker",
                 "tools/phar/composer-unused",
-                "tools/phar/composer",
                 "tools/phar/infection",
                 "tools/phar/phive",
                 "tools/phar/phpactor",
@@ -3060,7 +3060,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-14T11:57:46+00:00"
+            "time": "2025-09-14T12:18:56+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#e36feb1` to `dev-main#0179b4d`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`