### PR TITLE
Update ghostwriter/coding-standard to version dev-main#3766aaf

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1792,12 +1792,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "9a7b28951a64eb6a7c1527927c0296d70a76398a"
+                "reference": "3766aaf84ca3a90acdbd52cfa8a26819f1a8947d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9a7b28951a64eb6a7c1527927c0296d70a76398a",
-                "reference": "9a7b28951a64eb6a7c1527927c0296d70a76398a",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/3766aaf84ca3a90acdbd52cfa8a26819f1a8947d",
+                "reference": "3766aaf84ca3a90acdbd52cfa8a26819f1a8947d",
                 "shasum": ""
             },
             "require": {
@@ -1847,7 +1847,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.1",
-                "phpunit/phpunit": "^12.3.12",
+                "phpunit/phpunit": "^12.3.13",
                 "symfony/var-dumper": "^7.3.3"
             },
             "default-branch": true,
@@ -1954,7 +1954,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-22T07:37:05+00:00"
+            "time": "2025-09-23T07:02:20+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#9a7b289` to `dev-main#3766aaf`.

This pull request changes the following file(s): 

- Update `composer.lock`