### PR TITLE
Update boundwize/structarmed to version 0.6.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.14",
+        "boundwize/structarmed": "^0.6.15",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "92faab6c1e7d37cf7daae57e9ea7153b",
+    "content-hash": "24d8d7f6af83578cbd51ef81f34a9ebc",
     "packages": [
         {
             "name": "ghostwriter/clock",
@@ -1288,16 +1288,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.14",
+            "version": "0.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "74a38efeae3c995586dd16bf5935f98d249ee20d"
+                "reference": "1c9f1eac7058af6117b4581fbecaff001fb38e97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/74a38efeae3c995586dd16bf5935f98d249ee20d",
-                "reference": "74a38efeae3c995586dd16bf5935f98d249ee20d",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/1c9f1eac7058af6117b4581fbecaff001fb38e97",
+                "reference": "1c9f1eac7058af6117b4581fbecaff001fb38e97",
                 "shasum": ""
             },
             "require": {
@@ -1346,7 +1346,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.14"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.15"
             },
             "funding": [
                 {
@@ -1354,7 +1354,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-20T03:09:43+00:00"
+            "time": "2026-05-20T13:36:47+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -1423,16 +1423,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "362529f6642af30ab5f9dd8f58b198e96a574614"
+                "reference": "6439cb7c20121d26b48e7798f9ac69fc695ac8ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/362529f6642af30ab5f9dd8f58b198e96a574614",
-                "reference": "362529f6642af30ab5f9dd8f58b198e96a574614",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/6439cb7c20121d26b48e7798f9ac69fc695ac8ff",
+                "reference": "6439cb7c20121d26b48e7798f9ac69fc695ac8ff",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.14",
+                "boundwize/structarmed": "^0.6.15",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -1543,7 +1543,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-20T08:56:27+00:00"
+            "time": "2026-05-20T17:12:56+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.14` to `0.6.15`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`